### PR TITLE
fix: Move Supabase admin client creation to runtime to fix build error

### DIFF
--- a/src/app/api/submissions/[id]/route.ts
+++ b/src/app/api/submissions/[id]/route.ts
@@ -2,17 +2,22 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabase, Track } from '@/lib/supabase'
 import { createClient } from '@supabase/supabase-js'
 
-// Admin client with service role for bypassing RLS
-const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  {
+// Function to create admin client with service role for bypassing RLS
+function createSupabaseAdmin() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing required Supabase environment variables')
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false
     }
-  }
-)
+  })
+}
 
 export async function PUT(
   request: NextRequest,
@@ -100,6 +105,7 @@ export async function PUT(
 
       console.log('Inserting track data:', trackData)
 
+      const supabaseAdmin = createSupabaseAdmin()
       const { data: insertedTrack, error: trackError } = await supabaseAdmin
         .from('tracks')
         .insert(trackData)


### PR DESCRIPTION
• Moved createClient call from module initialization to function execution • Added proper error handling for missing environment variables • Fixes "supabaseKey is required" build error in production

🤖 Generated with [Claude Code](https://claude.ai/code)